### PR TITLE
Wrong name for sleep

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -1849,7 +1849,7 @@ static void *miner_thread(void *userdata)
 				work_done = true; // force "regen" hash
 			while (!work_done && time(NULL) >= (g_work_time + opt_scantime)) 
 			{
-				Sleep(1);
+				sleep(1);
 				if (sleeptime > 4) {
 					extrajob = true;
 					break;


### PR DESCRIPTION
Fixes build failing on Ubuntu 16.04-18.04